### PR TITLE
Messaging library refactor

### DIFF
--- a/core/src/main.cc
+++ b/core/src/main.cc
@@ -1,4 +1,4 @@
-#include "ProcessFilePaths.h"
+#include "Identifiers.h"
 #include "PowerRepository.h"
 #include "CommsRepository.h"
 #include "AdcsRepository.h"
@@ -7,7 +7,7 @@
 #include<stdlib.h>
 #include<iostream>
 
-ProcessFilePaths file_paths;
+Identifiers ids;
 
 int StartPowerRepository();
 int StartGpsRepository();
@@ -20,8 +20,8 @@ int StartPowerRepository(){
 	/*
 	 * Start power repository...
 	 */
-    PowerRepository power_server_(file_paths.power_repository);
-    power_server_.WaitForConnection();
+    PowerRepository power_server_(ids.power_repository);
+    power_server_.start();
 
 	return 1;
 }
@@ -32,8 +32,8 @@ int StartGpsRepository(){
 	/*
 	 * Start gps repository...
 	 */
-	GpsRepository gps_server_(file_paths.gps_repository);
-	gps_server_.WaitForConnection();
+	GpsRepository gps_server_(ids.gps_repository);
+	gps_server_.start();
 
 	return 1;
 }
@@ -43,8 +43,8 @@ int StartCommsRepository(){
 	/*
 	 * Start Comms repository...
 	 */
-	CommsRepository comms_server_(file_paths.comms_repository);
-	comms_server_.WaitForConnection();
+	CommsRepository comms_server_(ids.comms_repository);
+	comms_server_.start();
 	return 1;
 }
 
@@ -53,8 +53,8 @@ int StartPayloadRepository(){
 	/*
 	 * Start power repository...
 	 */
-	PayloadRepository payload_server_(file_paths.payload_repository);
-	payload_server_.WaitForConnection();
+	PayloadRepository payload_server_(ids.payload_repository);
+	payload_server_.start();
 
 	return 1;
 }
@@ -64,15 +64,15 @@ int StartAdcsRepository(){
 	/*
 	 * Start power repository...
 	 */
-	AdcsRepository adcs_server_(file_paths.adcs_repository);
-	adcs_server_.WaitForConnection();
+	AdcsRepository adcs_server_(ids.adcs_repository);
+	adcs_server_.start();
 	return 1;
 }
 
 int TestRepositories(){
 	//TODO have default constructor where the filepath is hard coded? But keep the current constructor optional
-    PowerRepository power_server_(file_paths.power_repository);
-     power_server_.WaitForConnection();
+    PowerRepository power_server_(ids.power_repository);
+     power_server_.start();
 
 //    CommsRepository comms_server_(file_paths.comms_repository);
 //	cout << file_paths.comms_repository << endl;

--- a/core/src/repositories/cc/AdcsRepository.cc
+++ b/core/src/repositories/cc/AdcsRepository.cc
@@ -4,8 +4,8 @@
 
 #include "AdcsRepository.h"
 
-AdcsRepository::AdcsRepository(std::string filePaths)
-        : Repository(filePaths) {}
+AdcsRepository::AdcsRepository(unsigned int identifier)
+        : Repository(identifier) {}
 
 //Adds all keys, to watch_list, for storing/returning future data
 int AdcsRepository::AddKeysToWatchList(){

--- a/core/src/repositories/cc/CommsRepository.cc
+++ b/core/src/repositories/cc/CommsRepository.cc
@@ -4,8 +4,8 @@
 
 #include "CommsRepository.h"
 
-CommsRepository::CommsRepository(std::string filePaths)
-        : Repository(filePaths) {}
+CommsRepository::CommsRepository(unsigned int identifier)
+        : Repository(identifier) {}
 
 //Adds all keys, to watch_list, for storing/returning future data
 int CommsRepository::AddKeysToWatchList(){

--- a/core/src/repositories/cc/GpsRepository.cc
+++ b/core/src/repositories/cc/GpsRepository.cc
@@ -4,8 +4,8 @@
 
 #include "GpsRepository.h"
 
-GpsRepository::GpsRepository(std::string filePaths)
-        : Repository(filePaths) {}
+GpsRepository::GpsRepository(unsigned int identifier)
+        : Repository(identifier) {}
 
 //Adds all keys, to watch_list, for storing/returning future data
 int GpsRepository::AddKeysToWatchList(){

--- a/core/src/repositories/cc/PayloadRepository.cc
+++ b/core/src/repositories/cc/PayloadRepository.cc
@@ -4,8 +4,8 @@
 
 #include "PayloadRepository.h"
 
-PayloadRepository::PayloadRepository(std::string filePaths)
-        : Repository(filePaths) {}
+PayloadRepository::PayloadRepository(unsigned int identifier)
+        : Repository(identifier) {}
 
 //Adds all keys, to watch_list, for storing/returning future data
 int PayloadRepository::AddKeysToWatchList(){

--- a/core/src/repositories/cc/PowerRepository.cc
+++ b/core/src/repositories/cc/PowerRepository.cc
@@ -3,11 +3,10 @@
 //
 
 #include "PowerRepository.h"
-
 #include "PowerKeys.h"
 
-PowerRepository::PowerRepository(std::string filePaths)
-        : Repository(filePaths) {
+PowerRepository::PowerRepository(unsigned int identifier)
+        : Repository(identifier) {
 	AddKeysToWatchList();
 }
 
@@ -29,7 +28,6 @@ int PowerRepository::AddKeysToWatchList(){
 int PowerRepository::ProcessMessage(DataMessage message){
 
 	/*Perform optional processing here*/
-
 
     return 0;
 }

--- a/core/src/repositories/cc/Repository.cc
+++ b/core/src/repositories/cc/Repository.cc
@@ -119,30 +119,32 @@ void Repository::start() {
 	Message *message;
 	mrs.StartListeningForClients();
 	while(true){
-		mrs.ListenForMessage(*message);
+		mrs.ListenForMessage(message);
 		if ( DataMessage * dm = dynamic_cast<DataMessage*>( message ) ) {
+			cout << "Message was a DataMessage" << endl;
 			//Extract any new, watched data from the message
-		ExtractDataFromReceivedMessage(*dm);
+			ExtractDataFromReceivedMessage(*dm);
 
-		//Perform any additional, optional processing for the message
-		ProcessMessage(*dm);
+			//Perform any additional, optional processing for the message
+			ProcessMessage(*dm);
 
-		//Build an empty reply message
-		DataMessage reply_message(this->repository_identifier(), dm->GetSender());
+			//Build an empty reply message
+			DataMessage reply_message(this->repository_identifier(), dm->GetSender());
 
-		//Append any requested data to the reply_message, if the repository has it
-		if(dm->HasRequests()){
-			BuildReturnDataMessage(*dm,reply_message);
-		}
+			//Append any requested data to the reply_message, if the repository has it
+			if(dm->HasRequests()){
+				BuildReturnDataMessage(*dm,reply_message);
+			}
 
-		//Reply to the client
-		ReplyToConnectedClient(reply_message);
+			//Reply to the client
+			ReplyToConnectedClient(reply_message);
 		}
 		else if ( CommandMessage * cm = dynamic_cast<CommandMessage*>( message ) ) {
 			//TODO Add process for command messages
 		}
 		else {
-		throw "unknown message type";
+			cout << "Unable to cast to a known message type" << endl;
+			throw "unknown message type";
 		}
 	}
 }

--- a/core/src/repositories/cc/Repository.cc
+++ b/core/src/repositories/cc/Repository.cc
@@ -74,6 +74,7 @@ bool Repository::WatchListContainsKey(unsigned int key){
 }
 
 int Repository::BuildReturnDataMessage(DataMessage request_message,DataMessage& return_message){
+	cout << "Building return message" << endl;
 	std::vector<int> requests = request_message.GetRequests();
 	int number_of_reqs=requests.size();
 	if(number_of_reqs>0){
@@ -126,9 +127,10 @@ void Repository::start() {
 			DataMessage reply_message(this->repository_identifier(), dm->GetSender());
 
 			//Append any requested data to the reply_message, if the repository has it
-			if(dm->HasRequests()){
-				BuildReturnDataMessage(*dm,reply_message);
-			}
+			// if(dm->HasRequests()){
+			cout << "Message has requests for information" << endl;
+			BuildReturnDataMessage(*dm,reply_message);
+			// }
 
 			//Reply to the client
 			ReplyToConnectedClient(reply_message);

--- a/core/src/repositories/cc/Repository.cc
+++ b/core/src/repositories/cc/Repository.cc
@@ -56,13 +56,7 @@ int Repository::ExtractDataFromReceivedMessage(DataMessage received_message){
 }
 
 int Repository::ReplyToConnectedClient(DataMessage& message){
-	//TODO Spencer, can I just arbitrarily set the length of the message? and send it? - Andrew
-    // char msg[255] = "";
-	// message.Flatten(msg);
 	mrs.Reply(message);
-	// int client_file_descriptor=this->current_client_file_descriptor();
-	// cout << "Replying to client at " << client_file_descriptor << " with message: " << msg << endl;
-	// WriteToSocket(msg,client_file_descriptor);
 	return 1;
 }
 

--- a/core/src/repositories/cc/Repository.cc
+++ b/core/src/repositories/cc/Repository.cc
@@ -127,13 +127,13 @@ void Repository::start() {
 			DataMessage reply_message(this->repository_identifier(), dm->GetSender());
 
 			//Append any requested data to the reply_message, if the repository has it
-			// if(dm->HasRequests()){
-			cout << "Message has requests for information" << endl;
-			BuildReturnDataMessage(*dm,reply_message);
-			// }
-
-			//Reply to the client
-			ReplyToConnectedClient(reply_message);
+			if(dm->HasRequests()){
+				cout << "Message has requests for information" << endl;
+				BuildReturnDataMessage(*dm,reply_message);
+				
+				//Reply to the client
+				ReplyToConnectedClient(reply_message);
+			}
 		}
 		else if ( CommandMessage * cm = dynamic_cast<CommandMessage*>( message ) ) {
 			//TODO Add process for command messages

--- a/core/src/repositories/header/AdcsRepository.h
+++ b/core/src/repositories/header/AdcsRepository.h
@@ -11,7 +11,7 @@
 
 class AdcsRepository : public Repository {
 public:
-    AdcsRepository(std::string filePaths);
+    AdcsRepository(unsigned int identifier);
     int ProcessMessage(DataMessage message);
     int AddKeysToWatchList();
 

--- a/core/src/repositories/header/CommsRepository.h
+++ b/core/src/repositories/header/CommsRepository.h
@@ -11,7 +11,7 @@
 
 class CommsRepository : public Repository {
 public:
-    CommsRepository(std::string filePaths);
+    CommsRepository(unsigned int identifier);
     int ProcessMessage(DataMessage message);
     int AddKeysToWatchList();
 

--- a/core/src/repositories/header/GpsRepository.h
+++ b/core/src/repositories/header/GpsRepository.h
@@ -11,7 +11,7 @@
 
 class GpsRepository : public Repository {
 public:
-    GpsRepository(std::string filePaths);
+    GpsRepository(unsigned int identifier);
     int ProcessMessage(DataMessage message);
     int AddKeysToWatchList();
 

--- a/core/src/repositories/header/PayloadRepository.h
+++ b/core/src/repositories/header/PayloadRepository.h
@@ -11,7 +11,7 @@
 
 class PayloadRepository : public Repository {
 public:
-    PayloadRepository(std::string filePaths);
+    PayloadRepository(unsigned int identifier);
     int ProcessMessage(DataMessage message);
     int AddKeysToWatchList();
 

--- a/core/src/repositories/header/PowerRepository.h
+++ b/core/src/repositories/header/PowerRepository.h
@@ -6,17 +6,15 @@
 #define LORIS_POWERREPOSITORY_H
 
 #include "Repository.h"
-// #include "../../message/identifiers/ProcessFilePaths.h"
 #include <string>
 
 class PowerRepository : public Repository {
 public:
-    PowerRepository(std::string filePaths);
+    PowerRepository(unsigned int identifier);
     int ProcessMessage(DataMessage message);
     unsigned int repository_identifier();
 
     int AddKeysToWatchList();
-
 
 };
 

--- a/core/src/repositories/header/Repository.h
+++ b/core/src/repositories/header/Repository.h
@@ -5,15 +5,17 @@
 #ifndef LORIS_REPOSITORY_H
 #define LORIS_REPOSITORY_H
 
+#include "Message.h"
 #include "DataMessage.h"
-#include "UnixDomainStreamSocketServer.h"
+#include "CommandMessage.h"
+#include "MessageReceivingService.h"
 #include <string>
 #include "Identifiers.h"
 
-class Repository : public UnixDomainStreamSocketServer {
+class Repository {
 public:
-    Repository(std::string socket_path);
-    int HandleMessage(char *buffer, int client_file_descriptor);
+    Repository(unsigned int identifier);
+    void start();
 
 protected:
     //TODO make watch_list_ a map
@@ -50,9 +52,8 @@ protected:
      */
     virtual unsigned int repository_identifier() = 0;
 
-
 private:
-
+    MessageReceivingService mrs;
     /**
      * Extracts key value pairs which the repository is designated to store
      * @param received_message
@@ -83,11 +84,6 @@ private:
      */
     virtual int ProcessMessage(DataMessage message) = 0;
     bool WatchListContainsKey(unsigned int key);
-
-
-
-
 };
-
 
 #endif //LORIS_REPOSITORY_H

--- a/internal-messaging/message/cc/CommandMessage.cc
+++ b/internal-messaging/message/cc/CommandMessage.cc
@@ -2,6 +2,7 @@
 #include <cstring>
 #include "CommandMessage.h"
 #include <stdexcept>
+#include <string>
 
 CommandMessage::CommandMessage()
 :CommandMessage(0,0)
@@ -30,6 +31,12 @@ CommandMessage::CommandMessage(char* flat)
     i = BuildContents(flat, i);
 }
 
+CommandMessage::CommandMessage(string flat) {
+	char cstr[flat.size() + 1];
+	std::strcpy(cstr, flat.c_str());	// or pass &s[0]
+	BuildFromCharacters(cstr);
+}
+
 void CommandMessage::Flatten(char* msg) {
     int message_size = 0;
     
@@ -47,4 +54,26 @@ void CommandMessage::Flatten(char* msg) {
     }
     // Add end char
     strcat(msg, message_break);
+}
+
+int CommandMessage::BuildFromCharacters(char *flat) {
+	std::cout << "Creating Data Message" << std::endl;
+	char integer_string[32];
+	char hex_string[32];
+	memset(integer_string, 0, 32);
+	memset(hex_string, 0, 32);
+	// Find sender, recipient, time and flag
+	int i = BuildHeader(flat, 0);
+	i++;
+
+	//TODO Spencer, should the flag be parsed in parent class Message? - Andrew
+	// Skip over flag
+	while (flat[i] != *section_break) {
+		i++;
+	}
+
+	// Find key value pairs
+	i++;
+	i = BuildContents(flat, i);
+	return 1;
 }

--- a/internal-messaging/message/cc/DataMessage.cc
+++ b/internal-messaging/message/cc/DataMessage.cc
@@ -35,18 +35,13 @@ int DataMessage::BuildFromCharacters(char *flat) {
 	// Find sender, recipient, time and flag
 	int i = BuildHeader(flat, 0);
 	i++;
-	//TODO Spencer, should the flag be parsed in parent class Message? - Andrew
-	// Skip over flag
-	while (flat[i] != *section_break) {
-		i++;
-	}
-	//i++;
 
 	//TODO Find more robust solution for when no requests exist
 	// Find Requests
-	while (flat[i] != *section_break && flat[i - 1] != *section_break) {
+	while (flat[i] != *section_break) {
+		std::cout << "Getting requests" << std::endl;
 		// Get next request
-		//TODO fix bug where infinite loop is reached due to no requests in the message
+		//TODO fix bug where infinite loop is reached due to no requests in the message -- I have not see this bug?
 		while (flat[i] != '-' && flat[i] != *section_break) {
 			sprintf(integer_string, "%c", flat[i]);
 			strcat(hex_string, integer_string);
@@ -54,7 +49,7 @@ int DataMessage::BuildFromCharacters(char *flat) {
 		}
 		try {
 			std::cout << "Adding: " << hex_string
-					<< "to requests in DataMessage" << std::endl;
+					<< " to requests in DataMessage" << std::endl;
 			int request = std::stoi(hex_string, nullptr, 16);
 			requests.push_back(request);
 		} catch (std::exception const &e) {

--- a/internal-messaging/message/cc/DataMessage.cc
+++ b/internal-messaging/message/cc/DataMessage.cc
@@ -65,7 +65,6 @@ int DataMessage::BuildFromCharacters(char *flat) {
 			i++;
 		};
 	}
-
 	// Find key value pairs
 	i++;
 	i = BuildContents(flat, i);

--- a/internal-messaging/message/cc/DataMessage.cc
+++ b/internal-messaging/message/cc/DataMessage.cc
@@ -26,12 +26,6 @@ DataMessage::DataMessage(char *flat) {
 	BuildFromCharacters(flat);
 }
 
-/**
- * Takes a character array, extracts data, and assigns it to class variables
- * This function assumes that flat is the "flattened" version of a pre-existing DataMessage
- * @param flat
- * @return
- */
 int DataMessage::BuildFromCharacters(char *flat) {
 	std::cout << "Creating Data Message" << std::endl;
 	char integer_string[32];

--- a/internal-messaging/message/cc/MessageBuilder.cc
+++ b/internal-messaging/message/cc/MessageBuilder.cc
@@ -1,4 +1,7 @@
 #include "MessageBuilder.h"
+#include "Message.h"
+#include "DataMessage.h"
+#include "CommandMessage.h"
 
 MessageBuilder::MessageBuilder()
 {
@@ -16,6 +19,35 @@ DataMessage MessageBuilder::CompleteMessage()
 {
     long current_time = (long)time(NULL);
     return DataMessage(this->current_sender_, this->current_recipient_, current_time, this->message_contents_);
+}
+
+int MessageBuilder::BuildMessageFromFlattened(Message &message, string flattened_message){
+    //count through section delimiters to find flag
+    int section_delimiters = 0;
+    string flag_string = "";
+    for(char& c : flattened_message){
+        if(section_delimiters == 3 && c != *section_break){ // Flag char is found
+            flag_string += c;
+        }
+        else if(c == *section_break){
+            section_delimiters++;
+        }
+        if(section_delimiters >= 4){
+            break;
+        }
+    }
+    int flag = std::stoi(flag_string, 0, 16); // Convert falg_string to base 10 flag
+    if(flag == 100){ //Data Message
+        message = DataMessage(flattened_message);
+        return 0;
+    }
+    else if(flag == 200){ //Command Message
+        message = CommandMessage(flattened_message);
+        return 0;
+    }
+    else{ // Unknown Message Type
+        return 1;
+    }
 }
 
 void MessageBuilder::SetRecipient(unsigned int recipient)

--- a/internal-messaging/message/cc/MessageBuilder.cc
+++ b/internal-messaging/message/cc/MessageBuilder.cc
@@ -21,7 +21,7 @@ DataMessage MessageBuilder::CompleteMessage()
     return DataMessage(this->current_sender_, this->current_recipient_, current_time, this->message_contents_);
 }
 
-int MessageBuilder::BuildMessageFromFlattened(Message &message, string flattened_message){
+int MessageBuilder::BuildMessageFromFlattened(Message *&message, string flattened_message){
     //count through section delimiters to find flag
     int section_delimiters = 0;
     string flag_string = "";
@@ -36,17 +36,19 @@ int MessageBuilder::BuildMessageFromFlattened(Message &message, string flattened
             break;
         }
     }
-    int flag = std::stoi(flag_string, 0, 16); // Convert falg_string to base 10 flag
+    int flag = std::stoi(flag_string, 0, 16); // Convert flag_string to base 10 flag
     if(flag == 100){ //Data Message
-        message = DataMessage(flattened_message);
-        return 0;
+        DataMessage *dm = new DataMessage(flattened_message);
+        message = static_cast<Message*>(dm);
+        return 1;
     }
     else if(flag == 200){ //Command Message
-        message = CommandMessage(flattened_message);
-        return 0;
+        CommandMessage cm(flattened_message);
+        message = static_cast<Message*>(&cm);
+        return 1;
     }
     else{ // Unknown Message Type
-        return 1;
+        return 0;
     }
 }
 

--- a/internal-messaging/message/header/CommandMessage.h
+++ b/internal-messaging/message/header/CommandMessage.h
@@ -2,6 +2,7 @@
 #ifndef LORIS_COMMANDMESSAGE_H
 #define LORIS_COMMANDMESSAGE_H
 #include "Message.h"
+using std::string;
 
 // Message used to send commands to a subsystem
 // CommandMessage format:
@@ -18,9 +19,21 @@ class CommandMessage : public Message{
         //Builds message from character array output of flatten method
         CommandMessage(char* flat);
 
+        CommandMessage(string flat);
+
         // Flattens message into a compressed character array that can be parsed by the Message(char* flat) constructor
         // msg - pointer to char array with a minimum size of 256 bytes.
         void Flatten(char* msg) override;
+
+    private: 
+        /**
+         * Takes a character array, extracts data, and assigns it to class variables
+         * This function assumes that flat is the "flattened" version of a pre-existing DataMessage
+         * @param flat
+         * @return
+         */
+        int BuildFromCharacters(char * flat);
+
 };
 
 #endif

--- a/internal-messaging/message/header/DataMessage.h
+++ b/internal-messaging/message/header/DataMessage.h
@@ -35,6 +35,12 @@ class DataMessage : public Message{
         bool HasRequests();
     private:
         std::vector<int> requests;
+        /**
+         * Takes a character array, extracts data, and assigns it to class variables
+         * This function assumes that flat is the "flattened" version of a pre-existing DataMessage
+         * @param flat
+         * @return
+         */
         int BuildFromCharacters(char * flat);
 };
 

--- a/internal-messaging/message/header/MessageBuilder.h
+++ b/internal-messaging/message/header/MessageBuilder.h
@@ -17,6 +17,10 @@ public:
     //Returns message object created
     DataMessage CompleteMessage();
 
+    //Builds a message from a flattened message string, will build proper message type
+    //based on flag and assign it to the Message object
+    static int BuildMessageFromFlattened(Message &message, string flattened_message);
+
     //Setters for message contents
     void SetRecipient(unsigned int recipient);
     void SetSender(unsigned int sender);

--- a/internal-messaging/message/header/MessageBuilder.h
+++ b/internal-messaging/message/header/MessageBuilder.h
@@ -19,7 +19,7 @@ public:
 
     //Builds a message from a flattened message string, will build proper message type
     //based on flag and assign it to the Message object
-    static int BuildMessageFromFlattened(Message &message, string flattened_message);
+    static int BuildMessageFromFlattened(Message *&message, string flattened_message);
 
     //Setters for message contents
     void SetRecipient(unsigned int recipient);

--- a/internal-messaging/messaging-service/cc/MessageRecievingService.cc
+++ b/internal-messaging/messaging-service/cc/MessageRecievingService.cc
@@ -4,6 +4,8 @@
 
 #include "MessageReceivingService.h"
 #include "PhoneBook.h"
+#include "MessageBuilder.h"
+#include <string>
 
 MessageReceivingService::MessageReceivingService(unsigned int identifier):
     server_socket_(PhoneBook::IdentifierToProcessFilePath(identifier)) {}
@@ -13,10 +15,17 @@ void MessageReceivingService::SetIdentifier(unsigned int identifier){
     server_socket_ = UnixDomainStreamSocketServer(path);
 }
 
-int ListenForMessage(Message &message){
-
+int MessageReceivingService::ListenForMessage(Message &message){
+    std::string flat_message;
+    server_socket_.HandleConnection(flat_message);
+    if(MessageBuilder::BuildMessageFromFlattened(message, flat_message) != 0){
+        throw "ERROR determining message type";
+        return 1;
+    }
+    return 0;
 }
 
-int ReplyWithDataMessage(DataMessage message){
-
+int MessageReceivingService::ReplyWithDataMessage(DataMessage message){
+    
+    return 0;
 }

--- a/internal-messaging/messaging-service/cc/MessageRecievingService.cc
+++ b/internal-messaging/messaging-service/cc/MessageRecievingService.cc
@@ -24,6 +24,7 @@ int MessageReceivingService::StartListeningForClients(){
 int MessageReceivingService::ListenForMessage(Message *&message){
     std::string flat_message;
     server_socket_.HandleConnection(flat_message);
+    cout << "Handling message: " << flat_message << endl; 
     if(MessageBuilder::BuildMessageFromFlattened(message, flat_message) == 0){
         throw "ERROR determining message type";
         return 0;
@@ -32,6 +33,9 @@ int MessageReceivingService::ListenForMessage(Message *&message){
 }
 
 int MessageReceivingService::Reply(Message &message){
-    
+    //TODO Message length should be set by repo - to come after refactor
+    char msg[255] = "";
+	message.Flatten(msg);
+    server_socket_.ReplyToCurrentClient(msg);
     return 0;
 }

--- a/internal-messaging/messaging-service/cc/MessageRecievingService.cc
+++ b/internal-messaging/messaging-service/cc/MessageRecievingService.cc
@@ -7,13 +7,19 @@
 #include "MessageBuilder.h"
 #include <string>
 
-MessageReceivingService::MessageReceivingService(unsigned int identifier):
+ MessageReceivingService::MessageReceivingService(unsigned int identifier):
     server_socket_(PhoneBook::IdentifierToProcessFilePath(identifier)) {}
 
 void MessageReceivingService::SetIdentifier(unsigned int identifier){
     std::string path = PhoneBook::IdentifierToProcessFilePath(identifier);
     server_socket_ = UnixDomainStreamSocketServer(path);
 }
+
+int MessageReceivingService::StartListeningForClients(){
+    server_socket_.StartListening();
+    return 0;
+}
+
 
 int MessageReceivingService::ListenForMessage(Message &message){
     std::string flat_message;
@@ -25,7 +31,7 @@ int MessageReceivingService::ListenForMessage(Message &message){
     return 0;
 }
 
-int MessageReceivingService::ReplyWithDataMessage(DataMessage message){
+int MessageReceivingService::Reply(Message &message){
     
     return 0;
 }

--- a/internal-messaging/messaging-service/cc/MessageRecievingService.cc
+++ b/internal-messaging/messaging-service/cc/MessageRecievingService.cc
@@ -21,14 +21,14 @@ int MessageReceivingService::StartListeningForClients(){
 }
 
 
-int MessageReceivingService::ListenForMessage(Message &message){
+int MessageReceivingService::ListenForMessage(Message *&message){
     std::string flat_message;
     server_socket_.HandleConnection(flat_message);
-    if(MessageBuilder::BuildMessageFromFlattened(message, flat_message) != 0){
+    if(MessageBuilder::BuildMessageFromFlattened(message, flat_message) == 0){
         throw "ERROR determining message type";
-        return 1;
+        return 0;
     }
-    return 0;
+    return 1;
 }
 
 int MessageReceivingService::Reply(Message &message){

--- a/internal-messaging/messaging-service/cc/MessageRecievingService.cc
+++ b/internal-messaging/messaging-service/cc/MessageRecievingService.cc
@@ -1,0 +1,22 @@
+//
+// Created by Spencer Axford on 2019-09-07.
+//
+
+#include "MessageReceivingService.h"
+#include "PhoneBook.h"
+
+MessageReceivingService::MessageReceivingService(unsigned int identifier):
+    server_socket_(PhoneBook::IdentifierToProcessFilePath(identifier)) {}
+
+void MessageReceivingService::SetIdentifier(unsigned int identifier){
+    std::string path = PhoneBook::IdentifierToProcessFilePath(identifier);
+    server_socket_ = UnixDomainStreamSocketServer(path);
+}
+
+int ListenForMessage(Message &message){
+
+}
+
+int ReplyWithDataMessage(DataMessage message){
+
+}

--- a/internal-messaging/messaging-service/cc/MessageRecipientInterface.cc
+++ b/internal-messaging/messaging-service/cc/MessageRecipientInterface.cc
@@ -1,3 +1,3 @@
 #include "MessageRecipientInterface.h"
 
-MessageRecipentInterface::MessageRecipientInterface(){}
+MessageRecipientInterface::MessageRecipientInterface(){}

--- a/internal-messaging/messaging-service/cc/MessageRecipientInterface.cc
+++ b/internal-messaging/messaging-service/cc/MessageRecipientInterface.cc
@@ -1,0 +1,3 @@
+#include "MessageRecipientInterface.h"
+
+MessageRecipentInterface::MessageRecipientInterface(){}

--- a/internal-messaging/messaging-service/header/MessageReceivingService.h
+++ b/internal-messaging/messaging-service/header/MessageReceivingService.h
@@ -1,0 +1,33 @@
+//
+// Created by Spencer Axford on 2019-05-15.
+//
+
+#ifndef LORIS_MESSAGERECEIVINGSERVICE_H
+#define LORIS_MESSAGERECEIVINGSERVICE_H
+
+#include "Message.h"
+#include "DataMessage.h"
+#include "UnixDomainStreamSocketServer.h"
+#include "MessageRecipientInterface.h"
+
+
+//A Messaging Service that allows for sending messages to a desiginated recipient 
+class MessageReceivingService : protected MessageRecipientInterface {
+
+public:
+    //Constructor
+    //identity is specified with Identifier int that specifies which system the messages are meant for (See Identifier.h)
+    MessageReceivingService(unsigned int identifier);
+    //Setter for Identifer after object construction
+    void SetIdentifier( unsigned int identifier);
+    
+    //Method to listen for, and recieve a message
+    int ListenForMessage(Message &message) override;
+    //Method to reply to last connected sender
+    int ReplyWithDataMessage(DataMessage message) override;
+    
+private:
+    UnixDomainStreamSocketServer server_socket_;
+};
+
+#endif //LORIS_MESSAGERECEIVINGSERVICE_H

--- a/internal-messaging/messaging-service/header/MessageReceivingService.h
+++ b/internal-messaging/messaging-service/header/MessageReceivingService.h
@@ -21,10 +21,13 @@ public:
     //Setter for Identifer after object construction
     void SetIdentifier( unsigned int identifier);
     
+    //Method to start listening on a socket path for a client (must call once before ListenForMessage)
+    int StartListeningForClients();
+
     //Method to listen for, and recieve a message
     int ListenForMessage(Message &message) override;
     //Method to reply to last connected sender
-    int ReplyWithDataMessage(DataMessage message) override;
+    int Reply(Message &message) override;
     
 private:
     UnixDomainStreamSocketServer server_socket_;

--- a/internal-messaging/messaging-service/header/MessageReceivingService.h
+++ b/internal-messaging/messaging-service/header/MessageReceivingService.h
@@ -25,7 +25,7 @@ public:
     int StartListeningForClients();
 
     //Method to listen for, and recieve a message
-    int ListenForMessage(Message &message) override;
+    int ListenForMessage(Message *&message) override;
     //Method to reply to last connected sender
     int Reply(Message &message) override;
     

--- a/internal-messaging/messaging-service/header/MessageRecipientInterface.h
+++ b/internal-messaging/messaging-service/header/MessageRecipientInterface.h
@@ -13,7 +13,7 @@ class MessageRecipientInterface {
 
 public:
     //Method to listen for, and recieve a message
-    virtual int ListenForMessage(Message &message) = 0;
+    virtual int ListenForMessage(Message *&message) = 0;
     //Method to reply to last connected sender
     virtual int Reply(Message &message) = 0;
 protected:

--- a/internal-messaging/messaging-service/header/MessageRecipientInterface.h
+++ b/internal-messaging/messaging-service/header/MessageRecipientInterface.h
@@ -15,7 +15,7 @@ public:
     //Method to listen for, and recieve a message
     virtual int ListenForMessage(Message &message) = 0;
     //Method to reply to last connected sender
-    virtual int ReplyWithDataMessage(DataMessage message) = 0;
+    virtual int Reply(Message &message) = 0;
 protected:
     //Constructor
     MessageRecipientInterface();

--- a/internal-messaging/messaging-service/header/MessageRecipientInterface.h
+++ b/internal-messaging/messaging-service/header/MessageRecipientInterface.h
@@ -1,0 +1,25 @@
+//
+// Created by Spencer Axford on 2019-09-07.
+//
+
+#ifndef LORIS_MESSAGERECIPIENTINTERFACE_H
+#define LORIS_MESSAGERECIPIENTINTERFACE_H
+
+#include "Message.h"
+#include "DataMessage.h"
+
+//A Messaging interface that allows for recieving messages
+class MessageRecipientInterface {
+
+public:
+    //Method to listen for, and recieve a message
+    virtual int ListenForMessage(Message &message) = 0;
+    //Method to reply to last connected sender
+    virtual int ReplyWithDataMessage(DataMessage message) = 0;
+protected:
+    //Constructor
+    MessageRecipientInterface();
+
+};
+
+#endif //LORIS_MESSAGERECIPIENTINTERFACE_H

--- a/internal-messaging/unixdomain/cc/UnixDomainStreamSocket.cc
+++ b/internal-messaging/unixdomain/cc/UnixDomainStreamSocket.cc
@@ -46,18 +46,17 @@ int UnixDomainStreamSocket::WriteToSocket(const char *msg, int new_socket_file_d
     return 0;
 }
 
-//TODO pass a buffer as an argument into this function rather than using some class/"global" one
 //Read from the socket specified by the sfd
-int UnixDomainStreamSocket::ReadFromSocket(int new_socket_file_descriptor, int buffer_capacity) {
-    ResetBuffer();
+int UnixDomainStreamSocket::ReadFromSocket(char* buffer, int new_socket_file_descriptor, int buffer_capacity) {
 
-    n_ = read(new_socket_file_descriptor, buffer_, buffer_capacity);
+    n_ = read(new_socket_file_descriptor, buffer, buffer_capacity);
 
     if (n_ < 0) {
         error("ERROR reading from socket");
-        return 0;
+        return 1;
     }
-    return HandleMessage(buffer_,new_socket_file_descriptor);
+
+    return 0;
 }
 
 //Prints error messages

--- a/internal-messaging/unixdomain/cc/UnixDomainStreamSocketClient.cc
+++ b/internal-messaging/unixdomain/cc/UnixDomainStreamSocketClient.cc
@@ -44,13 +44,13 @@ int UnixDomainStreamSocketClient::SendMessageAwaitReply(char message[], string &
     //TODO move capacity to a location where user can set it
     int capacity=255;
     char buf[capacity];
-	cout << "Reading from Socket..." << endl;
+	cout << "Reading from Socket " << socket_file_descriptor_ << " for a reply" << endl;
     if (ReadFromSocket(buf, socket_file_descriptor_,capacity) != 0) {
 
         error("ERROR READING FROM SOCKET");
         return 1;
     }
-    reply=GetReply();
+    reply=buf;
     return 0;
 }
 

--- a/internal-messaging/unixdomain/cc/UnixDomainStreamSocketClient.cc
+++ b/internal-messaging/unixdomain/cc/UnixDomainStreamSocketClient.cc
@@ -54,12 +54,6 @@ int UnixDomainStreamSocketClient::SendMessageAwaitReply(char message[], string &
     return 0;
 }
 
-//default implementation
-int UnixDomainStreamSocketClient::HandleMessage(char *buffer,int file_descriptor){
-    cout << "Handling message " << buffer << endl;
-    return 0;
-}
-
 string UnixDomainStreamSocketClient::GetReply(){
 	return GetBufferContents();
 }

--- a/internal-messaging/unixdomain/cc/UnixDomainStreamSocketClient.cc
+++ b/internal-messaging/unixdomain/cc/UnixDomainStreamSocketClient.cc
@@ -41,9 +41,11 @@ int UnixDomainStreamSocketClient::SendMessageAwaitReply(char message[], string &
         error("ERROR SENDING MESSAGE");
         return 1;
     }
+    //TODO move capacity to a location where user can set it
     int capacity=255;
+    char buf[capacity];
 	cout << "Reading from Socket..." << endl;
-    if (ReadFromSocket(socket_file_descriptor_,capacity) != 0) {
+    if (ReadFromSocket(buf, socket_file_descriptor_,capacity) != 0) {
 
         error("ERROR READING FROM SOCKET");
         return 1;

--- a/internal-messaging/unixdomain/cc/UnixDomainStreamSocketServer.cc
+++ b/internal-messaging/unixdomain/cc/UnixDomainStreamSocketServer.cc
@@ -73,6 +73,7 @@ int UnixDomainStreamSocketServer::HandleConnection(string &message) {
         char buf[buffer_size];
         ReadFromSocket(buf, current_client_socket_file_descriptor_, buffer_size);
         message = buf;
+        return 0;
     }
 }
 
@@ -80,6 +81,7 @@ int UnixDomainStreamSocketServer::StartListening(){
     //Indicate that the socket is for listening
     listen(socket_file_descriptor_, 5);
     cout << "Listening on socket " << socket_address_.sun_path << "..." << endl;
+    return 0;
 }
 
 // Clean way to print server info

--- a/internal-messaging/unixdomain/cc/UnixDomainStreamSocketServer.cc
+++ b/internal-messaging/unixdomain/cc/UnixDomainStreamSocketServer.cc
@@ -40,7 +40,7 @@ void UnixDomainStreamSocketServer::BindSocketToAddress(int socket_file_descripto
     }
 }
 
-int UnixDomainStreamSocketServer::current_client_file_descriptor(){
+int UnixDomainStreamSocketServer::GetCurrentClientFileDescriptor(){
 	return this->current_client_socket_file_descriptor_;
 }
 
@@ -92,4 +92,11 @@ void UnixDomainStreamSocketServer::ToString() {
     cout << "socket_address_.sun_path: " << socket_address_.sun_path << endl;
     cout << "&socket_address_: " << &socket_address_ << endl;
     cout << "socket_address_ size: " << sizeof(socket_address_) << endl;
+}
+
+int UnixDomainStreamSocketServer::ReplyToCurrentClient(char* message){
+    int client_file_descriptor = GetCurrentClientFileDescriptor();
+	cout << "Replying to client at " << client_file_descriptor << " with message: " << message << endl;
+	WriteToSocket(message, client_file_descriptor);
+    return 0;
 }

--- a/internal-messaging/unixdomain/header/UnixDomainStreamSocket.h
+++ b/internal-messaging/unixdomain/header/UnixDomainStreamSocket.h
@@ -54,10 +54,6 @@ protected:
     //clears current socket address struct
     void ClearAddress();
     
-    //Gets called once a message has arrived to the socket, this should be implimented by any repository in order to process and create Message object
-    //Return 0 if request handled successfully
-    //Return 1 if request handling failed
-    virtual int HandleMessage(char *buffer,int client_file_descriptor);
 public:
     string GetBufferContents();
 

--- a/internal-messaging/unixdomain/header/UnixDomainStreamSocket.h
+++ b/internal-messaging/unixdomain/header/UnixDomainStreamSocket.h
@@ -39,7 +39,7 @@ protected:
 
     //Reads message from socket with connection
     //new_socket_file_descripter - file descripter for socket file with waiting connection 
-    int ReadFromSocket(int new_socket_file_descriptor, int buffer_capacity);
+    int ReadFromSocket(char* buffer, int new_socket_file_descriptor, int buffer_capacity);
 
     //Sets up initial connection to socket when first created using socket path
     //sun_path - path to unix domain socket
@@ -57,7 +57,7 @@ protected:
     //Gets called once a message has arrived to the socket, this should be implimented by any repository in order to process and create Message object
     //Return 0 if request handled successfully
     //Return 1 if request handling failed
-    virtual int HandleMessage(char *buffer,int client_file_descriptor) = 0;
+    virtual int HandleMessage(char *buffer,int client_file_descriptor);
 public:
     string GetBufferContents();
 

--- a/internal-messaging/unixdomain/header/UnixDomainStreamSocketClient.h
+++ b/internal-messaging/unixdomain/header/UnixDomainStreamSocketClient.h
@@ -34,9 +34,4 @@ private:
     //initial connection to Unix Domain socket for data transfer
     //sun_path - local file system path to unix domain socket as character array
     int ConnectToSocket(char sun_path[]);
-
-    //Gets called once a message has arrived to the socket, this should be implimented by any repository in order to process and create Message object
-    //Return 0 if request handled successfully
-    //Return 1 if request handling failed
-    virtual int HandleMessage(char *buffer,int file_descriptor);
 };

--- a/internal-messaging/unixdomain/header/UnixDomainStreamSocketServer.h
+++ b/internal-messaging/unixdomain/header/UnixDomainStreamSocketServer.h
@@ -47,12 +47,15 @@ public:
 
     int current_client_file_descriptor();
 
+    //Starts listening on the socket file descriptor
+    int StartListening();
+
     //TODO Add a virtual function that allows the server to perform some operation in between waiting
     //TODO Find a way to continue looping IF there are no waiting clients. RIght now it just pauses.
     //TODO Checkout "fcntl". May potentially allow non-blocking mode
     //Method to poll socket for new connections from UnixDomainStreamSocketClients
     //Calls ReadFromSocket once a connection is found
-    virtual void WaitForConnection();
+    virtual int HandleConnection(string &message);
 };
 
 #endif // LORIS_UNIXDOMAIN_UNIXDOMAIN_SERVER_H_

--- a/internal-messaging/unixdomain/header/UnixDomainStreamSocketServer.h
+++ b/internal-messaging/unixdomain/header/UnixDomainStreamSocketServer.h
@@ -27,8 +27,6 @@ class UnixDomainStreamSocketServer : protected UnixDomainStreamSocket {
 private:
 
     int current_client_socket_file_descriptor_;
-    int socket_io_status_;
-    int servlen, n;
     socklen_t client_address_size;
     struct sockaddr_un client_address_;
 
@@ -45,17 +43,20 @@ public:
     //sock_path - local file system path to unix domain socket as string
     UnixDomainStreamSocketServer(string sock_path);
 
-    int current_client_file_descriptor();
+    int GetCurrentClientFileDescriptor();
 
     //Starts listening on the socket file descriptor
     int StartListening();
 
     //TODO Add a virtual function that allows the server to perform some operation in between waiting
-    //TODO Find a way to continue looping IF there are no waiting clients. RIght now it just pauses.
     //TODO Checkout "fcntl". May potentially allow non-blocking mode
     //Method to poll socket for new connections from UnixDomainStreamSocketClients
     //Calls ReadFromSocket once a connection is found
     virtual int HandleConnection(string &message);
+
+    //Sends message to the last file descriptor connected via HandleConnection
+    int ReplyToCurrentClient(char* message);
+
 };
 
 #endif // LORIS_UNIXDOMAIN_UNIXDOMAIN_SERVER_H_

--- a/internal-messaging/unixdomain/test/example/UDClientExample.cc
+++ b/internal-messaging/unixdomain/test/example/UDClientExample.cc
@@ -7,7 +7,3 @@
 UDClientExample::UDClientExample(char *sun_path)
         : UnixDomainStreamSocketClient(sun_path) {}
 
-int UDClientExample::HandleMessage(char *buffer){
-    cout << "Handling message " << buffer << endl;
-    return 0;
-}

--- a/internal-messaging/unixdomain/test/example/UDClientExample.h
+++ b/internal-messaging/unixdomain/test/example/UDClientExample.h
@@ -12,10 +12,6 @@
 class UDClientExample : public UnixDomainStreamSocketClient {
 public:
     UDClientExample(char sun_path[]);
-
-    //Return 0 if request handled successfully
-    //Return 1 if request handling failed
-    int HandleMessage(char *buffer);
 };
 
 #endif //DALCUBESAT_UXCLIENTEXAMPLE_H

--- a/internal-messaging/unixdomain/test/example/UDServerExample.cc
+++ b/internal-messaging/unixdomain/test/example/UDServerExample.cc
@@ -6,8 +6,3 @@
 
 UDServerExample::UDServerExample(std::string sun_path)
 : UnixDomainStreamSocketServer(sun_path) {}
-
-int UDServerExample::HandleMessage(char *buffer){
-    cout << "Handling message " << buffer << endl;
-    return 0;
-}

--- a/internal-messaging/unixdomain/test/example/UDServerExample.h
+++ b/internal-messaging/unixdomain/test/example/UDServerExample.h
@@ -16,9 +16,6 @@ class UDServerExample : public UnixDomainStreamSocketServer {
 public:
 
     UDServerExample(std::string sun_path);
-    //Return 0 if request handled successfully
-    //Return 1 if request handling failed
-    int HandleMessage(char *buffer);
 };
 
 


### PR DESCRIPTION
Some TODO's are left. After this is merged I will be going back and completing TODOs as well as setting up a variable message size. 

All UnixDomainStreamSocketServer operations are now handled by MessageReceivingService. 

Repositories now have a run loop in the form of the start() method. 

All receiving processes operate with pointers to Message objects, for DataMessage or CommandMessage specific actions dynamic_casts can be done to ensure proper type handling. 