### PR TITLE
IPC callbacks now offer message origin (src)

### DIFF
--- a/src/api/client_api/inc/client_api.h
+++ b/src/api/client_api/inc/client_api.h
@@ -144,7 +144,7 @@ int ipc_qsend(char dest[NAME_LEN], char* msg, size_t msg_len);
  * IPC_QRECV_MSG)
  * @return 0 = OK, ERROR < 0
  */
-int ipc_qrecv(char src[NAME_LEN], int (*callback)(char*, size_t, void*),
+int ipc_qrecv(char src[NAME_LEN], int (*callback)(char*, char*, size_t, void*),
               void* data, int flags);
 
 /**
@@ -160,7 +160,8 @@ int ipc_qrecv(char src[NAME_LEN], int (*callback)(char*, size_t, void*),
  * @return 0 = OK, ERROR < 0
  */
 int ipc_create_listener(char src[NAME_LEN],
-                        int (*callback)(char*, size_t, void*), void* data);
+                        int (*callback)(char*, char*, size_t, void*),
+                        void* data);
 
 /**
  * @brief Removes background listener(s) with matching source name.

--- a/src/api/client_api/src/client_api.c
+++ b/src/api/client_api/src/client_api.c
@@ -469,7 +469,8 @@ int ipc_qsend(char dest[NAME_LEN], char *msg, size_t msg_len) {
 }
 
 // Adds incoming message request to recv queue
-int ipc_qrecv(char src[NAME_LEN], int (*callback)(char *, size_t, void *),
+int ipc_qrecv(char src[NAME_LEN],
+              int (*callback)(char[NAME_LEN], char *, size_t, void *),
               void *data, int flags) {
   // Set which dibs array to refer to
   MsgReqDib *dibs_array;
@@ -509,7 +510,8 @@ int ipc_qrecv(char src[NAME_LEN], int (*callback)(char *, size_t, void *),
 
 // Creates background listener for incoming messages
 int ipc_create_listener(char src[NAME_LEN],
-                        int (*callback)(char *, size_t, void *), void *data) {
+                        int (*callback)(char[NAME_LEN], char *, size_t, void *),
+                        void *data) {
   return ipc_qrecv(src, callback, data, IPC_QRECV_MSG);
 }
 
@@ -624,7 +626,7 @@ int ipc_refresh_src(char src[NAME_LEN], int flags) {
             }
 
             // Run callback
-            dibs_array[x].callback(msg, msg_len, dibs_array[x].data);
+            dibs_array[x].callback(name, msg, msg_len, dibs_array[x].data);
 
             // done
             break;
@@ -735,7 +737,7 @@ int ipc_disconnect() {
 }
 
 // Callback for ipc_recv
-static int cb_recv(char *msg, size_t msg_len, void *data) {
+static int cb_recv(char *src, char *msg, size_t msg_len, void *data) {
   // Copy incoming message into data
   strncpy((char *)data, msg, msg_len);
   ((char *)data)[msg_len] = '\0';

--- a/src/api/client_api/src/client_api.c
+++ b/src/api/client_api/src/client_api.c
@@ -28,7 +28,7 @@ static ipc_packet_t packets[MAX_NUM_PACKETS];  // Incoming packet queue
 //////////////////////
 
 // Callback which is used by ipc_recv
-static int cb_recv(char *, size_t, void *);
+static int cb_recv(char *, char *, size_t, void *);
 
 // Thread wrapper for callback methods
 static int cb_thread(void *data);

--- a/src/api/libipc/examples/CLIENT_API_EXAMPLES.md
+++ b/src/api/libipc/examples/CLIENT_API_EXAMPLES.md
@@ -184,6 +184,7 @@ CALLBACK(general) {
 ```
 
 Although invisible when using the macro, there are 3 function parameters that are automatically passed to the callback function. They are:
+- `char* src` ==> pointer to name of the message source,
 - `char* msg` ==> pointer to the incoming message, 
 - `size_t msg_len` ==> length of the message stored at `msg`, 
 - `void* data` ==> custom pointer that you can setup (more on this later). 
@@ -194,9 +195,10 @@ An example use case of these parameters:
 ...
 
 CALLBACK(general) {
-  modprintf("Incoming message: %s\n", msg);   // <-- char* msg
-  modprintf("Message length: %d\n", msg_len); // <-- size_t msg_len
-  modprintf("Data pointer: %p\n", data);      // <-- void* data (may be NULL)
+  modprintf("Incoming message from %s: \n", src);   // <-- char src[3]
+  modprintf("Message content: %s\n", msg);          // <-- char* msg
+  modprintf("Message length: %d\n", msg_len);       // <-- size_t msg_len
+  modprintf("Data pointer: %p\n", data);            // <-- void* data (may be NULL)
 }
 
 ...

--- a/src/api/libipc/inc/msg_req_dib.h
+++ b/src/api/libipc/inc/msg_req_dib.h
@@ -26,7 +26,7 @@ extern "C" {
 // Message Request 'Dib' type
 typedef struct msg_req_dib {
   char name[NAME_LEN];
-  int (*callback)(char*, size_t, void*);
+  int (*callback)(char*, char*, size_t, void*);
   void* data;
   pid_t pid;
   char stack[MAX_DIB_STACK];
@@ -47,7 +47,8 @@ MsgReqDib MsgReqDib_new();
 
 // Returns initialized dib
 MsgReqDib MsgReqDib_set(char name[NAME_LEN],
-                        int (*callback)(char*, size_t, void*), void* data);
+                        int (*callback)(char*, char*, size_t, void*),
+                        void* data);
 
 // Appends or overwrites dib into dib array
 int MsgReqDib_add(MsgReqDib element, MsgReqDib* array, size_t array_len);
@@ -57,7 +58,7 @@ bool MsgReqDib_exists(char name[NAME_LEN], MsgReqDib* array, size_t array_len);
 
 // Checks in array for exact match of preexisting dib
 bool MsgReqDib_exists_exact(char name[NAME_LEN],
-                            int (*callback)(char*, size_t, void*),
+                            int (*callback)(char*, char*, size_t, void*),
                             MsgReqDib* array, size_t array_len);
 
 // Checks if callback for dib is running

--- a/src/api/libipc/inc/subsysmod.h
+++ b/src/api/libipc/inc/subsysmod.h
@@ -45,7 +45,8 @@ typedef struct subsystem_module {
 
 #define START_MODULE(name) int start_module_##name(void* data)
 #define STOP_MODULE(name) int stop_module_##name(void* data)
-#define CALLBACK(name) static int name(char* msg, size_t msg_len, void* data)
+#define CALLBACK(name) \
+  static int name(char src[NAME_LEN], char* msg, size_t msg_len, void* data)
 #define STOP_CALLBACK return 0
 
 #ifdef __cplusplus

--- a/src/api/libipc/src/msg_req_dib.c
+++ b/src/api/libipc/src/msg_req_dib.c
@@ -16,7 +16,8 @@ MsgReqDib MsgReqDib_new() {
 
 // Returns initialized dib
 MsgReqDib MsgReqDib_set(char name[NAME_LEN],
-                        int (*callback)(char *, size_t, void *), void *data) {
+                        int (*callback)(char *, char *, size_t, void *),
+                        void *data) {
   MsgReqDib dib = {.callback = callback, .data = data, .pid = -1};
   strncpy(dib.name, name, NAME_LEN);
 
@@ -96,7 +97,7 @@ bool MsgReqDib_exists(char name[NAME_LEN], MsgReqDib *array, size_t array_len) {
 
 // Checks in array for exact match of preexisting dib
 bool MsgReqDib_exists_exact(char name[NAME_LEN],
-                            int (*callback)(char *, size_t, void *),
+                            int (*callback)(char *, char *, size_t, void *),
                             MsgReqDib *array, size_t array_len) {
   // Search for existing dibs
   bool msg_has_dibs = false;


### PR DESCRIPTION
Hey guys,

Quick update to the IPC. 

Up until now, when making callback functions for background listeners on the IPC, you were provided with the message (`msg`), the message length (`msg_len`) and a custom data pointer (`data`). But when making wildcard (`*`) callbacks, there was no way to know where the incoming message came from. 

In this update, a new field is provided to IPC callback functions which contains the message source (`src`). 

The documentation at http://cubesat.alexamellal.com/md_src_api_libipc_examples_CLIENT_API_EXAMPLES.html was updated to include this field accordingly. 

Let me know if you have any questions or suggestions.

Peace